### PR TITLE
Updating url params and updating pver

### DIFF
--- a/lib/safe_browse.js
+++ b/lib/safe_browse.js
@@ -120,7 +120,7 @@ function SafeBrowseApi( apiKey, params ) {
     delete params.debug;
 
     // merge specified params with the default one
-    params = _.defaults(params, SafeBrowseApi.defaults, { apikey: apiKey });
+    params = _.defaults(params, SafeBrowseApi.defaults, { key: apiKey });
 
     // Utility log method
     log =  DEBUG
@@ -341,9 +341,9 @@ function SafeBrowseApi( apiKey, params ) {
 
 SafeBrowseApi.defaults = {
     client:  'Node Safe-Browse',
-    apikey:  null,
+    key:  null,
     appver:  '1.0.0', // format = major.minor.patch
-    pver:    '3.0' // format = major.minor
+    pver:    '3.1' // format = major.minor
 };
 
 


### PR DESCRIPTION
URL now expects key instead of apikey
Also pver is 3.1 so updated that too
